### PR TITLE
Include scenarios to validate the parsing of content

### DIFF
--- a/core/javascript-parser/src/Parser.ts
+++ b/core/javascript-parser/src/Parser.ts
@@ -1,21 +1,21 @@
 import { parseCell } from '@observablehq/parser'
 
 export interface ImportStatement {
-    type: 'import';
-    names: Array<{ name: string; alias: string }>;
-    urn: string;
+  type: 'import';
+  names: Array<{ name: string; alias: string }>;
+  urn: string;
 }
 
 export interface AssignmentStatement {
-    type: 'assignment';
-    name?: string;
-    dependencies: Array<string>;
-    body: string;
+  type: 'assignment';
+  name?: string;
+  dependencies: Array<string>;
+  body: string;
 }
 
 export interface ExceptionStatement {
-    type: 'exception';
-    exception: any;
+  type: 'exception';
+  exception: any;
 }
 
 export type ParseResult = AssignmentStatement | ImportStatement | ExceptionStatement;
@@ -26,10 +26,10 @@ export const parse = (code: string): ParseResult => {
 
     if (ast?.body?.type === 'ImportDeclaration') {
       const names: Array<{ name: string; alias: string }> =
-                ast.body.specifiers.map((s: any) => ({ name: s.imported.name, alias: s.local.name }))
+        ast.body.specifiers.map((s: any) => ({ name: s.imported.name, alias: s.local.name }))
 
       const urn: string =
-                ast.body.source.value
+        ast.body.source.value
 
       return { type: 'import', names, urn }
     } else {

--- a/core/javascript-parser/src/__tests__/Parser.test.ts
+++ b/core/javascript-parser/src/__tests__/Parser.test.ts
@@ -1,11 +1,50 @@
-import { parse } from '../Parser'
+import { parse, type AssignmentStatement, type ExceptionStatement, type ImportStatement } from '../index'
 
 describe('Parser', () => {
-  test('Expression', () => {
-    const ast: any = parse('1 + 2')
+  test('Simple expression', () => {
+    const ast = parse('1 + 2') as AssignmentStatement
 
-    expect(ast.dependencies).toEqual([])
-    expect(ast.name).toBeUndefined()
     expect(ast.type).toEqual('assignment')
+    expect(ast.name).toBeUndefined()
+    expect(ast.dependencies).toEqual([])
+    expect(ast.body).toEqual('1 + 2')
+  })
+
+  describe('Assignment', () => {
+    test('Simple', () => {
+      const ast = parse('x = y + 2') as AssignmentStatement
+
+      expect(ast.type).toEqual('assignment')
+      expect(ast.name).toEqual('x')
+      expect(ast.dependencies).toEqual(['y'])
+      expect(ast.body).toEqual('y + 2')
+    })
+
+    test('Block', () => {
+      const ast = parse('x = { const z = y + 2; return z + 1; }') as AssignmentStatement
+
+      expect(ast.type).toEqual('assignment')
+      expect(ast.name).toEqual('x')
+      expect(ast.dependencies).toEqual(['y'])
+      expect(ast.body).toEqual('{ const z = y + 2; return z + 1; }')
+    })
+  })
+
+  test('Import', () => {
+    const ast = parse('import { a as a1, b } from \'https://hello.world/bob.md\'') as ImportStatement
+
+    expect(ast.type).toEqual('import')
+    expect(ast.names).toEqual([
+      { alias: 'a1', name: 'a' },
+      { alias: 'b', name: 'b' }
+    ])
+    expect(ast.urn).toEqual('https://hello.world/bob.md')
+  })
+
+  test('Error', () => {
+    const ast = parse('import { a as a1 b } from \'https://hello.world/bob.md\'') as ExceptionStatement
+
+    expect(ast.type).toEqual('exception')
+    expect(ast.exception).toBeTruthy()
   })
 })


### PR DESCRIPTION
At present the parser is a simple wrapper over observable's parser hiding as much of the detail as possible.  The downside of this approach is that there are a number of scenarios which are obscured and are not executable.